### PR TITLE
Use {@param} command to declare template parameters instead of SoyDoc. Include Param Types.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -63,6 +63,34 @@ A collection of cool hidden and not so hidden features, to be used as a quick re
 {/template}
 ```
 
+###### primitive types
+
+```
+string
+bool
+int
+float
+number
+```
+
+###### other types
+
+```
+any
+?
+null
+html
+```
+
+###### complex types
+
+```
+list<Type>                // List
+map<KeyType, ValueType>   // Map
+[a:KeyType, b:ValueType]  // Record
+Type1|Type2               // Union
+```
+
 ## Call
 
 ```

--- a/readme.md
+++ b/readme.md
@@ -37,11 +37,28 @@ A collection of cool hidden and not so hidden features, to be used as a quick re
 
 ## Parameters
 
+###### required
+
 ```
 /**
- * @param name
+ *
  */
 {template .hello}
+	{@param name: string}
+
+	Hello {$name}
+{/template}
+```
+
+###### optional
+
+```
+/**
+ *
+ */
+{template .hello}
+	{@param? name: string}
+
 	Hello {$name}
 {/template}
 ```


### PR DESCRIPTION
@zenorocha I'll be sending another pull in a little bit with the links to the Docs that we talked about. 

Let me know if you would like me to make any adjustments. Thanks :)