### PR TITLE
Improve elvis and ternary operator descriptions

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -215,16 +215,18 @@ Type1|Type2               // Union
 
 > [See Docs](https://developers.google.com/closure/templates/docs/commands#switch "Switch")
 
-###### elvis
-
-```
-Hello {$name ?: 'there'}
-```
-
 ###### ternary
 
 ```
-{$name ? 'Hello {$name}' : 'Hello there'}
+{isNonnull($name) ? 'Hello {$name}' : 'Hello there'}
+```
+
+> [See Docs](https://developers.google.com/closure/templates/docs/concepts#operators "Operators")
+
+###### elvis (null-coalescing)
+
+```
+Hello {$name ?: 'there'}
 ```
 
 > [See Docs](https://developers.google.com/closure/templates/docs/concepts#operators "Operators")


### PR DESCRIPTION
- Fix the ternary example with `isNonnull` so that it is easily comparable with the elvis operator
- Switch the ternary and null-coalescing operator, so that reading the first (`a?b:c`) makes it clear what the last does (`a?:c`)
- Add link to the docs for the elvis operator too